### PR TITLE
split rollup config file with prod and local 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "unpkg": "dist/jinabox.umd.min.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "mkdir -p dist && rollup -c"
+    "build": "mkdir -p dist && rollup -c && rollup --config rollup.config.prod.js",
+    "build:dev": "mkdir -p dist && rollup -c"
   },
   "files": [
     "dist/"

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -1,14 +1,24 @@
 const nodeResolve = require('@rollup/plugin-node-resolve').default;
 const babel = require('rollup-plugin-babel');
+const { terser } = require('rollup-plugin-terser');
 const postcss = require('rollup-plugin-postcss');
 
 const babelConfig = require('./babel.config');
 const extensions = ['.js'];
 
+const terserConfig = {
+  compress: {
+    pure_getters: true,
+    unsafe: true,
+    unsafe_comps: true,
+    warnings: false,
+  }
+};
+
 module.exports = {
     input: 'src/jinabox.js',
     output: {
-      file: 'dist/jinabox.umd.js',
+      file: 'dist/jinabox.umd.min.js',
       format: 'umd',
     },
     plugins: [
@@ -18,6 +28,7 @@ module.exports = {
         extensions,
         exclude: 'node_modules/**',
       }),
+      terser(terserConfig),
       postcss(),
     ],
   };


### PR DESCRIPTION
spit rollup file to prod and local.


why need this :

development in local does not need to build [jinabox.umd.js]() and [jinabox.umd.min.js](). I think to build one file  [jinabox.umd.js]()  is enough. and will save **build time**.  