### PR TITLE
fix: topk parameter parsing

### DIFF
--- a/src/jinabox.js
+++ b/src/jinabox.js
@@ -45,7 +45,9 @@ window.JinaBox = {
 			}
 			xhr.timeout = timeout;
 			xhr.ontimeout = () => reject('Search Timeout');
-			xhr.send(JSON.stringify({ data, top_k: parseInt(top_k), mode: 'search' }));
+			xhr.send(JSON.stringify({ data,
+				parameters: {top_k: parseInt(top_k)},
+				mode: 'search' }));
 		})
 	},
 	updateSettings: function (settings) {


### PR DESCRIPTION
Closes #33 .
When trying to use the Jina 2.0 API with jinabox, the top_k parameter is not parsed correctly.
The parameter needs to be inside the parameters JSON argument.